### PR TITLE
Read block size as a signed integer

### DIFF
--- a/src/classes/RandomAccessFile.js
+++ b/src/classes/RandomAccessFile.js
@@ -107,6 +107,20 @@ class RandomAccessFile {
 	}
 
 	/**
+	 * Read a 4-byte signed integer from the buffer
+	 *
+	 * @category Data
+	 * @returns {number}
+	 */
+	readSInt4() {
+		const int = this.readSignedIntLocal(this.offset, 4);
+		this.offset += 4;
+
+		return int;
+	}
+
+
+	/**
 	 * Read a 2-byte unsigned integer from the buffer
 	 *
 	 * @category Data

--- a/src/decompress.js
+++ b/src/decompress.js
@@ -47,7 +47,7 @@ const decompress = (raf) => {
 	// loop until the end of the file is reached
 	while (raf.getPos() < raf.getLength()) {
 		// block size may be negative
-		const size = Math.abs(raf.readInt());
+		const size = Math.abs(raf.readSInt4());
 		// store the position
 		positions.push({
 			pos: raf.getPos(),


### PR DESCRIPTION
I've been trying to parse radar files client-side (Chrome), but I kept getting a bzip error even though the files parse server-side (node). I found that the block size was being parsed as over 4 billion bytes, which I recognized as a negative number being parsed as an unsigned int.

Your code had a comment, "block size may be negative", and you were running the size through Math.abs(), but you were reading an unsigned integer. I added a "readSInt4" function to read a 4-byte signed integer and called that instead to get the block size, and now the file parses client-side with no errors.

I don't know why this worked under Node but not the client. My test file was KLOT20220317_000842_V06.